### PR TITLE
Allow all addresses to connect to dev server

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -14,8 +14,9 @@ const devConfig = {
     new webpack.DefinePlugin(globals),
   ],
   devServer: {
-    hot: true,
+    host: '0.0.0.0',
     port: process.env.PORT || 3000,
+    hot: true,
     stats: 'minimal',
     historyApiFallback: true,
   },


### PR DESCRIPTION
This allows you to connect to the dev server with an IP address, to test on external devices for example.